### PR TITLE
fix: avoid mutating menu when deleting product

### DIFF
--- a/src/components/Admin/AdminPanel.jsx
+++ b/src/components/Admin/AdminPanel.jsx
@@ -88,9 +88,16 @@ const AdminPanel = () => {
   };
 
   const handleDeleteProduct = (categoryIndex, productIndex) => {
-     const newMenu = [...menu];
-     newMenu[categoryIndex].products.splice(productIndex, 1);
-     updateMenu(newMenu);
+    const newMenu = menu.map((category, idx) => {
+      if (idx === categoryIndex) {
+        return {
+          ...category,
+          products: category.products.filter((_, pIdx) => pIdx !== productIndex),
+        };
+      }
+      return category;
+    });
+    updateMenu(newMenu);
   };
 
   return (


### PR DESCRIPTION
## Summary
- avoid mutating menu state when removing product in admin panel

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689522203080832ca21697b92893214d